### PR TITLE
Fixed bug in type guessing.

### DIFF
--- a/csv2sqlite.py
+++ b/csv2sqlite.py
@@ -72,14 +72,14 @@ def _guess_types(fileobj, max_sample_size=100):
                     # for null cells we can assume success
                     if cell:
                         cast(cell)
-                    results[idx][key] = (results[idx][key]*count + 1) / float(count+1)
+                    results[idx][key] += 1
                 except (ValueError), inst:
                     pass
         if count >= max_sample_size:
             break
     for idx,colresult in enumerate(results):
         for _type, dontcare in options:
-            if colresult[_type] == 1.0:
+            if colresult[_type] == count + 1:
                 types[idx] = _type
     return types
 


### PR DESCRIPTION
This fixes a bug where _guess_types() did not always determine numerical types correctly.  If _guess_types() examined a column of mixed floating-point and integer numbers, and the first value in the column happened to be an integer, then the code would always conclude that it was an integer column, which is obviously incorrect.  If the first value was a floating point, it worked as expected.  This was a consequence of the math that was used in line 75 of the script, and the check later (line 82) to see if the final values are equal to 1.  It should now work correctly for all cases.
