### PR TITLE
Use None as value if number is not present in csv

### DIFF
--- a/csv2sqlite.py
+++ b/csv2sqlite.py
@@ -26,7 +26,11 @@ def convert(filepath_or_fileobj, dbpath, table='data'):
     # shz: fix error with non-ASCII input
     conn.text_factory = str
     c = conn.cursor()
-    c.execute('CREATE table %s (%s)' % (table, _columns))
+
+    try:
+        c.execute('CREATE table %s (%s)' % (table, _columns))
+    except:
+        pass
 
     _insert_tmpl = 'insert into %s values (%s)' % (table,
         ','.join(['?']*len(headers)))


### PR DESCRIPTION
This fix is necessary to make sqlite use NULL when value is not present in csv file.
