### PR TITLE
Prevent warnings for blank lines

### DIFF
--- a/csv2sqlite.py
+++ b/csv2sqlite.py
@@ -35,6 +35,8 @@ def convert(filepath_or_fileobj, dbpath, table='data'):
     _insert_tmpl = 'insert into %s values (%s)' % (table,
         ','.join(['?']*len(headers)))
     for row in reader:
+        if len(row) == 0:
+            continue
         # we need to take out commas from int and floats for sqlite to
         # recognize them properly ...
         row = [


### PR DESCRIPTION
Added check which prevents warning like the following from occurring each time a blank line is encountered.

> Error on line '[]' Incorrect number of bindings supplied. The current statement uses 1, and there are 0 supplied.
