### PR TITLE
Defining the count variable in order to eliminate the following warning ...

### DIFF
--- a/csv2sqlite.py
+++ b/csv2sqlite.py
@@ -77,6 +77,7 @@ def _guess_types(fileobj, max_sample_size=100):
         'text': 0
         }
     results = [ dict(perresult) for x in range(len(_headers)) ]
+    count =  0
     for count,row in enumerate(reader):
         for idx,cell in enumerate(row):
             cell = cell.strip()


### PR DESCRIPTION
...generated when guessing types:

Traceback (most recent call last):
  File "/Users/khowe/bin/csv2sqlite.py", line 113, in <module>
    convert(*sys.argv[1:])
  File "/Users/khowe/bin/csv2sqlite.py", line 17, in convert
    types = _guess_types(fo)
  File "/Users/khowe/bin/csv2sqlite.py", line 98, in _guess_types
    if colresult[_type] == count + 1:
UnboundLocalError: local variable 'count' referenced before assignment
