### PR TITLE
fixed missing import sys for sys.stderr call

### DIFF
--- a/csv2sqlite.py
+++ b/csv2sqlite.py
@@ -8,6 +8,7 @@
 
 from __future__ import print_function
 
+import sys
 import argparse
 import csv
 import sqlite3


### PR DESCRIPTION
at least did not work without it, on a "mal formatted csv", 